### PR TITLE
Update code to initialize planner

### DIFF
--- a/AcademicCalendar.txt
+++ b/AcademicCalendar.txt
@@ -1,52 +1,53 @@
-1:Vacation
-2:Vacation
-3:Week 1
-4:Week 2
-5:Week 3
-6:Week 4
-7:Week 5
-8:Week 6
-9:Recess Week
-10:Week 7
-11:Week 8
-12:Week 9
-13:Week 10
-14:Week 11
-15:Week 12
-16:Week 13
-17:Reading Week
-18:Examination Week
-19:Examination Week
-20:Vacation
-21:Vacation
-22:Vacation
-23:Vacation
-24:Vacation
-25:Vacation
-26:Vacation
-27:Vacation
-28:Vacation
-29:Vacation
-30:Vacation
-31:Vacation
-32:Orientation Week
-33:Week 1
-34:Week 2
-35:Week 3
-36:Week 4
-37:Week 5
-38:Week 6
-39:Recess Week
-40:Week 7
-41:Week 8
-42:Week 9
-43:Week 10
-44:Week 11
-45:Week 12
-46:Week 13
-47:Reading Week
-48:Examination Week
-49:Examination Week
-50:Vacation
-51:Vacation
-52:Vacation
+1:Vacation_Sem 1
+2:Vacation_Sem 1
+3:Week 1_Sem 2
+4:Week 2_Sem 2
+5:Week 3_Sem 2
+6:Week 4_Sem 2
+7:Week 5_Sem 2
+8:Week 6_Sem 2
+9:Recess Week_Sem 2
+10:Week 7_Sem 2
+11:Week 8_Sem 2
+12:Week 9_Sem 2
+13:Week 10_Sem 2
+14:Week 11_Sem 2
+15:Week 12_Sem 2
+16:Week 13_Sem 2
+17:Reading Week_Sem 2
+18:Examination Week_Sem 2
+19:Examination Week_Sem 2
+20:Vacation_Sem 2
+21:Vacation_Sem 2
+22:Vacation_Sem 2
+23:Vacation_Sem 2
+24:Vacation_Sem 2
+25:Vacation_Sem 2
+26:Vacation_Sem 2
+27:Vacation_Sem 2
+28:Vacation_Sem 2
+29:Vacation_Sem 2
+30:Vacation_Sem 2
+31:Vacation_Sem 2
+32:Orientation Week_Sem 1
+33:Week 1_Sem 1
+34:Week 2_Sem 1
+35:Week 3_Sem 1
+36:Week 4_Sem 1
+37:Week 5_Sem 1
+38:Week 6_Sem 1
+39:Recess Week_Sem 1
+40:Week 7_Sem 1
+41:Week 8_Sem 1
+42:Week 9_Sem 1
+43:Week 10_Sem 1
+44:Week 11_Sem 1
+45:Week 12_Sem 1
+46:Week 13_Sem 1
+47:Reading Week_Sem 1
+48:Examination Week_Sem 1
+49:Examination Week_Sem 1
+50:Vacation_Sem 1
+51:Vacation_Sem 1
+52:Vacation_Sem 1
+53:Vacation_Sem 1

--- a/src/planmysem/data/Planner.java
+++ b/src/planmysem/data/Planner.java
@@ -132,6 +132,7 @@ public class Planner {
                 break;
             default:
                 normalDays.add(date);
+                break;
             }
         }
         //System.out.println(recessDays);

--- a/src/planmysem/data/Planner.java
+++ b/src/planmysem/data/Planner.java
@@ -3,10 +3,11 @@ package planmysem.data;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.TemporalField;
 import java.time.temporal.WeekFields;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,99 +31,41 @@ public class Planner {
      * Creates an empty planner.
      */
     public Planner() {
-        String filePath = "AcademicCalendar.txt";
-        String acadWeek = null;
-        String acadYear = null;
-        String acadSem = null;
-        int noOfWeeks = 0;
-        Calendar cal = Calendar.getInstance();
-        int currentWeekOfYear = cal.get(Calendar.WEEK_OF_YEAR);
-        int currentYear = cal.get(Calendar.YEAR);
-        LocalDate startDate = LocalDate.now();
-        LocalDate endDate = LocalDate.now();
-        // TODO: add recess days, reading days, normal days
+        String acadWeek;
+        String acadSem;
+        String acadYear;
+        String[] semesterDetails;
+        int noOfWeeks;
+        LocalDate startDate;
+        LocalDate endDate;
+        List<LocalDate> datesList;
+        Map<String, String> acadCalMap;
+        HashMap<LocalDate, Day> days = new HashMap<>();
         Set<LocalDate> recessDays = new HashSet<>();
         Set<LocalDate> readingDays = new HashSet<>();
         Set<LocalDate> normalDays = new HashSet<>();
-        Map<String, String> acadCalMap = null;
-
-        // Read AcademicCalendar.txt to get current academic week
-        try {
-            Stream<String> lines = Files.lines(Paths.get(filePath));
-            acadCalMap = lines
-                    .collect(Collectors.toMap(key -> key.split(":")[0], val -> val.split(":")[1]));
-            acadWeek = acadCalMap.get(Integer.toString(currentWeekOfYear));
-        } catch (IOException ioe) {
-            // TODO: remove displaying of errors
-            // What if file is unable to be read?
-            ioe.getMessage();
-        }
-        //System.out.println(acadCalMap);
-
-        // Set variables if it is currently vacation
-        if (acadWeek != null && acadWeek.equals("Vacation")) {
-            acadSem = "Vacation";
-            if (currentWeekOfYear < 3 || currentWeekOfYear > 49) {
-                noOfWeeks = 5;
-
-                cal.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY);
-                cal.set(Calendar.WEEK_OF_YEAR, 50);
-                startDate = LocalDate.of(currentYear, 12, cal.get(Calendar.DATE));
-
-                cal.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY);
-                cal.set(Calendar.WEEK_OF_YEAR, 2);
-                endDate = LocalDate.of(currentYear, 1, cal.get(Calendar.DATE));
-            }
-            if (currentWeekOfYear > 19 && currentWeekOfYear < 32) {
-                noOfWeeks = 12;
-
-                cal.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY);
-                cal.set(Calendar.WEEK_OF_YEAR, 20);
-                startDate = LocalDate.of(currentYear, 5, cal.get(Calendar.DATE));
-
-                cal.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY);
-                cal.set(Calendar.WEEK_OF_YEAR, 31);
-                endDate = LocalDate.of(currentYear, 8, cal.get(Calendar.DATE));
-            }
-        }
-
-        // Set variables if it is currently not vacation
-        if (currentWeekOfYear > 31 && currentWeekOfYear < 50) {
-            acadYear = "AY" + currentYear + "/" + (currentYear + 1);
-            acadSem = "Sem 1";
-            noOfWeeks = 18;
-
-            cal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
-            cal.set(Calendar.WEEK_OF_YEAR, 32);
-            startDate = LocalDate.of(currentYear, 8, cal.get(Calendar.DATE));
-
-            cal.set(Calendar.DAY_OF_WEEK, Calendar.SATURDAY);
-            cal.set(Calendar.WEEK_OF_YEAR, 49);
-            endDate = LocalDate.of(currentYear, 12, cal.get(Calendar.DATE));
-        }
-        if (currentWeekOfYear > 2 && currentWeekOfYear < 20) {
-            acadYear = "AY" + (currentYear - 1) + "/" + currentYear;
-            acadSem = "Sem 2";
-            noOfWeeks = 17;
-
-            cal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
-            cal.set(Calendar.WEEK_OF_YEAR, 3);
-            startDate = LocalDate.of(currentYear, 1, cal.get(Calendar.DATE));
-
-            cal.set(Calendar.DAY_OF_WEEK, Calendar.SATURDAY);
-            cal.set(Calendar.WEEK_OF_YEAR, 19);
-            endDate = LocalDate.of(currentYear, 5, cal.get(Calendar.DATE));
-        }
-
-        // Initialise hashmap of all days in current semester
-        HashMap<LocalDate, Day> days = new HashMap<>();
-        List<LocalDate> datesList = startDate.datesUntil(endDate).collect(Collectors.toList());
+        
+        acadCalMap = getAcadCalMap();
+        TemporalField weekField = WeekFields.ISO.weekOfWeekBasedYear();
+        int currentWeekOfYear = LocalDate.now().get(weekField);
+        semesterDetails = getSemesterDetails(currentWeekOfYear, acadCalMap);
+        acadWeek = semesterDetails[0];
+        acadSem = semesterDetails[1];
+        acadYear = semesterDetails[2];
+        noOfWeeks = Integer.parseInt(semesterDetails[3]);
+        startDate = LocalDate.parse(semesterDetails[4]);
+        endDate = LocalDate.parse(semesterDetails[5]);
+        
+        // Initialises HashMap and Sets of all days in current semester
+        datesList = startDate.datesUntil(endDate).collect(Collectors.toList());
         for (LocalDate date: datesList) {
-            TemporalField weekField = WeekFields.ISO.weekOfWeekBasedYear();
-            String weekOfYear = Integer.toString(date.get(weekField));
-            String weekType = acadCalMap.get(weekOfYear);
+            int weekOfYear = date.get(weekField);
+            int firstMonOfYear = date.with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY)).getDayOfMonth();
+            if (firstMonOfYear == 1) {
+                weekOfYear += 1;
+            }
+            String weekType = acadCalMap.get(Integer.toString(weekOfYear)).split("_")[0];
             days.put(date, new Day(date.getDayOfWeek(), weekType));
-            // TODO: Add type of the day here, recess/reading or normal
             switch (weekType) {
             case "Recess Week":
                 recessDays.add(date);
@@ -135,12 +78,9 @@ public class Planner {
                 break;
             }
         }
-        //System.out.println(recessDays);
-        //System.out.println(readingDays);
-        //System.out.println(normalDays);
+        
         semester = new Semester(acadSem, acadYear, days, startDate, endDate, noOfWeeks,
                 recessDays, readingDays, normalDays);
-        // TODO: set constants for fixed numbers, simplify/optimise code, handle ioe exception
     }
 
     /**
@@ -156,6 +96,103 @@ public class Planner {
         return new Planner();
     }
 
+    /**
+     * Reads a file containing academic calendar details.
+     *
+     * @return a map of week of year to academic week
+     * throws some exception if a AcademicCalendar.txt is unable to be read.
+     */
+    private Map<String, String> getAcadCalMap() {
+        String filePath = "AcademicCalendar.txt";
+        Map<String, String> acadCalMap = null;
+        try {
+            Stream<String> lines = Files.lines(Paths.get(filePath));
+            acadCalMap = lines
+                    .collect(Collectors.toMap(key -> key.split(":")[0], val -> val.split(":")[1]));
+        } catch (IOException ioe) {
+            // TODO: remove displaying of errors
+            // What if file is unable to be read?
+            ioe.getMessage();
+        }
+        return acadCalMap;
+    }
+
+    /**
+     * Initialises current semester's details.
+     *
+     * @param currentWeekOfYear current week of the year
+     * @param acadCalMap used to determine current academic week
+     * @return an array of Strings of the current semester's details
+     */
+    private String[] getSemesterDetails(int currentWeekOfYear, Map<String, String> acadCalMap) {
+        String acadWeek = null;
+        String acadSem = null;
+        String acadYear = null;
+        String noOfWeeks = null;
+        String[] acadWeekDetails;
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = LocalDate.now();
+        int currentYear = LocalDate.now().getYear();
+        // Initialise week numbers for certain weeks.
+        int firstWeekSemOne = 32;
+        int lastWeekSemOne = 49;
+        int firstWeekSemOneHol = 50;
+        int lastWeekSemOneHol = 2;
+        int firstWeekSemTwo = 3;
+        int lastWeekSemTwo = 19;
+        int firstWeekSemTwoHol = 20;
+        int lastWeekSemTwoHol = 31;
+        int firstMonOfYear = LocalDate.of(currentYear, 1, 1)
+                .with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY)).getDayOfMonth();
+        // Readjust weeks if first Monday of the year falls on the 1st.
+        if (firstMonOfYear == 1) {
+            currentWeekOfYear += 1;
+            firstWeekSemOne -= 1;
+            lastWeekSemOne -= 1;
+            firstWeekSemOneHol -= 1;
+            lastWeekSemOneHol -= 1;
+            firstWeekSemTwo -= 1;
+            lastWeekSemTwo -= 1;
+            firstWeekSemTwoHol -= 1;
+            lastWeekSemTwoHol -= 1;
+        }
+        // Set semester details.
+        acadWeekDetails = acadCalMap.get(Integer.toString(currentWeekOfYear)).split("_");
+        acadWeek = acadWeekDetails[0];
+        acadSem = acadWeekDetails[1];
+        if (acadWeek.equals("Vacation") && acadSem.equals("Sem 1")) {
+            noOfWeeks = "5";
+            acadYear = "AY" + currentYear + "/" + (currentYear + 1);
+            startDate = startDate.with(WeekFields.ISO.weekOfWeekBasedYear(), firstWeekSemOneHol);
+            startDate = startDate.with(WeekFields.ISO.dayOfWeek(), 1);
+            endDate = LocalDate.of(currentYear + 1, 1, 1);
+            endDate = endDate.with(WeekFields.ISO.weekOfWeekBasedYear(), lastWeekSemOneHol);
+            endDate = endDate.with(WeekFields.ISO.dayOfWeek(), 7);
+        } else if (acadWeek.equals("Vacation") && acadSem.equals("Sem 2")) {
+            noOfWeeks = "12";
+            acadYear = "AY" + (currentYear - 1) + "/" + currentYear;
+            startDate = startDate.with(WeekFields.ISO.weekOfWeekBasedYear(), firstWeekSemTwoHol);
+            startDate = startDate.with(WeekFields.ISO.dayOfWeek(), 1);
+            endDate = endDate.with(WeekFields.ISO.weekOfWeekBasedYear(), lastWeekSemTwoHol);
+            endDate = endDate.with(WeekFields.ISO.dayOfWeek(), 7);
+        } else if (acadSem.equals("Sem 1")) {
+            noOfWeeks = "18";
+            acadYear = "AY" + currentYear + "/" + (currentYear + 1);
+            startDate = startDate.with(WeekFields.ISO.weekOfWeekBasedYear(), firstWeekSemOne);
+            startDate = startDate.with(WeekFields.ISO.dayOfWeek(), 1);
+            endDate = endDate.with(WeekFields.ISO.weekOfWeekBasedYear(), lastWeekSemOne);
+            endDate = endDate.with(WeekFields.ISO.dayOfWeek(), 7);
+        } else if (acadSem.equals("Sem 2")) {
+            noOfWeeks = "17";
+            acadYear = "AY" + (currentYear - 1) + "/" + currentYear;
+            startDate = startDate.with(WeekFields.ISO.weekOfWeekBasedYear(), firstWeekSemTwo);
+            startDate = startDate.with(WeekFields.ISO.dayOfWeek(), 1);
+            endDate = endDate.with(WeekFields.ISO.weekOfWeekBasedYear(), lastWeekSemTwo);
+            endDate = endDate.with(WeekFields.ISO.dayOfWeek(), 7);
+        }
+        return new String[] {acadWeek, acadSem, acadYear, noOfWeeks, startDate.toString(), endDate.toString()};
+    }
+    
     /**
      * Adds a day to the Planner.
      *

--- a/src/planmysem/data/Planner.java
+++ b/src/planmysem/data/Planner.java
@@ -43,7 +43,6 @@ public class Planner {
         Set<LocalDate> recessDays = new HashSet<>();
         Set<LocalDate> readingDays = new HashSet<>();
         Set<LocalDate> normalDays = new HashSet<>();
-        Map<String, String> acadCalMap = null;
 
         acadCalMap = getAcadCalMap();
         TemporalField weekField = WeekFields.ISO.weekOfWeekBasedYear();

--- a/src/planmysem/data/Planner.java
+++ b/src/planmysem/data/Planner.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDate;
+import java.time.temporal.TemporalField;
+import java.time.temporal.WeekFields;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,17 +44,20 @@ public class Planner {
         Set<LocalDate> recessDays = new HashSet<>();
         Set<LocalDate> readingDays = new HashSet<>();
         Set<LocalDate> normalDays = new HashSet<>();
+        Map<String, String> acadCalMap = null;
 
         // Read AcademicCalendar.txt to get current academic week
         try {
             Stream<String> lines = Files.lines(Paths.get(filePath));
-            Map<String, String> acadCalMap = lines
+            acadCalMap = lines
                     .collect(Collectors.toMap(key -> key.split(":")[0], val -> val.split(":")[1]));
             acadWeek = acadCalMap.get(Integer.toString(currentWeekOfYear));
         } catch (IOException ioe) {
             // TODO: remove displaying of errors
+            // What if file is unable to be read?
             ioe.getMessage();
         }
+        //System.out.println(acadCalMap);
 
         // Set variables if it is currently vacation
         if (acadWeek != null && acadWeek.equals("Vacation")) {
@@ -113,9 +118,25 @@ public class Planner {
         HashMap<LocalDate, Day> days = new HashMap<>();
         List<LocalDate> datesList = startDate.datesUntil(endDate).collect(Collectors.toList());
         for (LocalDate date: datesList) {
-            days.put(date, new Day(date.getDayOfWeek(), ""));
+            TemporalField weekField = WeekFields.ISO.weekOfWeekBasedYear();
+            String weekOfYear = Integer.toString(date.get(weekField));
+            String weekType = acadCalMap.get(weekOfYear);
+            days.put(date, new Day(date.getDayOfWeek(), weekType));
             // TODO: Add type of the day here, recess/reading or normal
+            switch (weekType) {
+            case "Recess Week":
+                recessDays.add(date);
+                break;
+            case "Reading Week":
+                readingDays.add(date);
+                break;
+            default:
+                normalDays.add(date);
+            }
         }
+        //System.out.println(recessDays);
+        //System.out.println(readingDays);
+        //System.out.println(normalDays);
         semester = new Semester(acadSem, acadYear, days, startDate, endDate, noOfWeeks,
                 recessDays, readingDays, normalDays);
         // TODO: set constants for fixed numbers, simplify/optimise code, handle ioe exception

--- a/src/planmysem/data/Planner.java
+++ b/src/planmysem/data/Planner.java
@@ -31,7 +31,6 @@ public class Planner {
      * Creates an empty planner.
      */
     public Planner() {
-        String acadWeek;
         String acadSem;
         String acadYear;
         String[] semesterDetails;
@@ -44,18 +43,17 @@ public class Planner {
         Set<LocalDate> recessDays = new HashSet<>();
         Set<LocalDate> readingDays = new HashSet<>();
         Set<LocalDate> normalDays = new HashSet<>();
-        
+
         acadCalMap = getAcadCalMap();
         TemporalField weekField = WeekFields.ISO.weekOfWeekBasedYear();
         int currentWeekOfYear = LocalDate.now().get(weekField);
         semesterDetails = getSemesterDetails(currentWeekOfYear, acadCalMap);
-        acadWeek = semesterDetails[0];
         acadSem = semesterDetails[1];
         acadYear = semesterDetails[2];
         noOfWeeks = Integer.parseInt(semesterDetails[3]);
         startDate = LocalDate.parse(semesterDetails[4]);
         endDate = LocalDate.parse(semesterDetails[5]);
-        
+
         // Initialises HashMap and Sets of all days in current semester
         datesList = startDate.datesUntil(endDate).collect(Collectors.toList());
         for (LocalDate date: datesList) {
@@ -78,7 +76,7 @@ public class Planner {
                 break;
             }
         }
-        
+
         semester = new Semester(acadSem, acadYear, days, startDate, endDate, noOfWeeks,
                 recessDays, readingDays, normalDays);
     }
@@ -133,6 +131,8 @@ public class Planner {
         LocalDate startDate = LocalDate.now();
         LocalDate endDate = LocalDate.now();
         int currentYear = LocalDate.now().getYear();
+        int weekOfYear = currentWeekOfYear;
+
         // Initialise week numbers for certain weeks.
         int firstWeekSemOne = 32;
         int lastWeekSemOne = 49;
@@ -144,9 +144,10 @@ public class Planner {
         int lastWeekSemTwoHol = 31;
         int firstMonOfYear = LocalDate.of(currentYear, 1, 1)
                 .with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY)).getDayOfMonth();
+
         // Readjust weeks if first Monday of the year falls on the 1st.
         if (firstMonOfYear == 1) {
-            currentWeekOfYear += 1;
+            weekOfYear += 1;
             firstWeekSemOne -= 1;
             lastWeekSemOne -= 1;
             firstWeekSemOneHol -= 1;
@@ -156,11 +157,12 @@ public class Planner {
             firstWeekSemTwoHol -= 1;
             lastWeekSemTwoHol -= 1;
         }
+
         // Set semester details.
-        acadWeekDetails = acadCalMap.get(Integer.toString(currentWeekOfYear)).split("_");
+        acadWeekDetails = acadCalMap.get(Integer.toString(weekOfYear)).split("_");
         acadWeek = acadWeekDetails[0];
         acadSem = acadWeekDetails[1];
-        if (acadWeek.equals("Vacation") && acadSem.equals("Sem 1")) {
+        if ("Vacation".equals(acadWeek) && "Sem 1".equals(acadSem)) {
             noOfWeeks = "5";
             acadYear = "AY" + currentYear + "/" + (currentYear + 1);
             startDate = startDate.with(WeekFields.ISO.weekOfWeekBasedYear(), firstWeekSemOneHol);
@@ -168,21 +170,21 @@ public class Planner {
             endDate = LocalDate.of(currentYear + 1, 1, 1);
             endDate = endDate.with(WeekFields.ISO.weekOfWeekBasedYear(), lastWeekSemOneHol);
             endDate = endDate.with(WeekFields.ISO.dayOfWeek(), 7);
-        } else if (acadWeek.equals("Vacation") && acadSem.equals("Sem 2")) {
+        } else if ("Vacation".equals(acadWeek) && "Sem 2".equals(acadSem)) {
             noOfWeeks = "12";
             acadYear = "AY" + (currentYear - 1) + "/" + currentYear;
             startDate = startDate.with(WeekFields.ISO.weekOfWeekBasedYear(), firstWeekSemTwoHol);
             startDate = startDate.with(WeekFields.ISO.dayOfWeek(), 1);
             endDate = endDate.with(WeekFields.ISO.weekOfWeekBasedYear(), lastWeekSemTwoHol);
             endDate = endDate.with(WeekFields.ISO.dayOfWeek(), 7);
-        } else if (acadSem.equals("Sem 1")) {
+        } else if ("Sem 1".equals(acadSem)) {
             noOfWeeks = "18";
             acadYear = "AY" + currentYear + "/" + (currentYear + 1);
             startDate = startDate.with(WeekFields.ISO.weekOfWeekBasedYear(), firstWeekSemOne);
             startDate = startDate.with(WeekFields.ISO.dayOfWeek(), 1);
             endDate = endDate.with(WeekFields.ISO.weekOfWeekBasedYear(), lastWeekSemOne);
             endDate = endDate.with(WeekFields.ISO.dayOfWeek(), 7);
-        } else if (acadSem.equals("Sem 2")) {
+        } else if ("Sem 2".equals(acadSem)) {
             noOfWeeks = "17";
             acadYear = "AY" + (currentYear - 1) + "/" + currentYear;
             startDate = startDate.with(WeekFields.ISO.weekOfWeekBasedYear(), firstWeekSemTwo);
@@ -192,7 +194,7 @@ public class Planner {
         }
         return new String[] {acadWeek, acadSem, acadYear, noOfWeeks, startDate.toString(), endDate.toString()};
     }
-    
+
     /**
      * Adds a day to the Planner.
      *

--- a/src/planmysem/data/semester/Day.java
+++ b/src/planmysem/data/semester/Day.java
@@ -20,12 +20,12 @@ public class Day implements ReadOnlyDay {
      */
     public Day(DayOfWeek dayOfWeek, String weekType) {
         this.dayOfWeek = dayOfWeek;
-        this.type = null;
+        this.type = weekType;
     }
 
     public Day(DayOfWeek dayOfWeek, String weekType, ArrayList<Slot> slots) {
         this.dayOfWeek = dayOfWeek;
-        this.type = null;
+        this.type = weekType;
 
         for (Slot slot : slots) {
             this.slots.add(slot);

--- a/src/planmysem/data/semester/Day.java
+++ b/src/planmysem/data/semester/Day.java
@@ -16,7 +16,6 @@ public class Day implements ReadOnlyDay {
 
     /**
      * Assumption: Every field must be present and not null.
-     * TODO: Ding Heng, please init type
      */
     public Day(DayOfWeek dayOfWeek, String weekType) {
         this.dayOfWeek = dayOfWeek;


### PR DESCRIPTION
Migrate use of `java.util.Calendar` to new Java 8 Date Time API, `java.time`.
Initialize `weekType` for each `Day`.
Update code to cater for special academic years which start on 2nd week of the year.